### PR TITLE
Refactor: Modularize program into a reading | compare | output pipeline

### DIFF
--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -38,12 +38,12 @@ function compare_bounds(model1::MOI.ModelLike, model2::MOI.ModelLike; kws...)
     return compare_bounds(model1, model2, compare_variables(model1, model2); kws...)
 end
 
-function printdiff(io::IO, bdiff::BoundsDiff)
+function printdiff(io::IO, bdiff::BoundsDiff; one_by_one::Bool)
     both, only1, only2 = bdiff.both, bdiff.first, bdiff.second
 
     print_header(io, "VARIABLE BOUNDS")
 
-    if true #compare_one_by_one
+    if one_by_one
         ## For each variable, print the difference between models
         if !isempty(both)
             write(io, "\tSAME VARIABLES\n")

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -10,7 +10,7 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
     if separate_files
         (basename, ext) = Base.Filesystem.splitext(outfile)
         outvar = "$(basename)_variables$(ext)"
-        outobj = "$(basename)_object$(ext)"
+        outobj = "$(basename)_objective$(ext)"
         outbnd = "$(basename)_bounds$(ext)"
         outcon = "$(basename)_constraints$(ext)"
     else
@@ -21,25 +21,45 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
     model1 = readmodel(file1)
     model2 = readmodel(file2)
 
-    model1,model2 = read_from_file(file1, file2)
-    sorted_variable_1 = sort(collect(model1.var_to_name), by=x->x[2])
-    sorted_variable_2 = sort(collect(model2.var_to_name), by=x->x[2])
-    all_variables_1 = [[var[1].value,var[2]] for var in sorted_variable_1]
-    all_variables_2 = [[var[1].value,var[2]] for var in sorted_variable_2]
-    n_var_1 = length(all_variables_1)
-    n_var_2 = length(all_variables_2)
-    
+    # ~:~ Processing ~:~ #
     if separate_files
-        openvar = open(outvar,"w+")
-        lists = compare_variables(all_variables_1, all_variables_2, openvar)
+        println("Comparing Variables...")
+        vardiff    = compare_variables(model1, model2)
+        open(io -> printdiff(io, vardiff), outvar,"w+")
+
+        if get_bounds
+            println("Comparing Variable Bounds...")
+            boundsdiff = compare_bounds(model1, model2, vardiff; tol = tol)
+            open(io -> printdiff(io, boundsdiff), outbnd,"w+")
+        end
     else
-        lists = compare_variables(all_variables_1, all_variables_2, openfile)
+        println("Comparing Variables...")
+        vardiff    = compare_variables(model1, model2)
+        printdiff(openfile, vardiff)
+
+        if get_bounds
+            println("Comparing Variable Bounds...")
+            boundsdiff = compare_bounds(model1, model2, vardiff; tol = tol)
+            printdiff(openfile, boundsdiff)
+        end
     end
-    equals_names,equals_names_index_1,equals_names_index_2,diffs2,diffs2_index,diffs1,diffs1_index = lists
+
+    close(openfile)
+    return
+
+    equals_names = var_same
+    equals_names_index_1 = filter(p -> first(p) in var_same, indices1)
+    equals_names_index_2 = filter(p -> first(p) in var_same, indices2)
+    diffs1 = var1
+    diffs2 = var2
+    diffs1_index = filter(p -> first(p) in var1, indices1)
+    diffs2_index = filter(p -> first(p) in var2, indices2)
+
     if get_objective
         if separate_files
-            openobj = open(outobj,"w+")
-            compare_objective(model1,model2,lists, openobj, tol, compare_one_by_one)
+            open(outobj,"w+") do openobj
+              compare_objective(model1,model2,lists, openobj, tol, compare_one_by_one)
+            end
         else
             compare_objective(model1,model2,lists, openfile, tol, compare_one_by_one)
         end
@@ -64,10 +84,6 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
     end
 
     if separate_files
-        close(openvar)
-        if get_objective
-            close(openobj)
-        end
         if get_bounds
             close(openbnd)
         end

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -30,7 +30,7 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
         if get_bounds
             println("Comparing Variable Bounds...")
             boundsdiff = compare_bounds(model1, model2, vardiff; tol = tol)
-            open(io -> printdiff(io, boundsdiff), outbnd,"w+")
+            open(io -> printdiff(io, boundsdiff; one_by_one = true), outbnd,"w+")
         end
     else
         println("Comparing Variables...")
@@ -40,11 +40,11 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
         if get_bounds
             println("Comparing Variable Bounds...")
             boundsdiff = compare_bounds(model1, model2, vardiff; tol = tol)
-            printdiff(openfile, boundsdiff)
+            printdiff(openfile, boundsdiff; one_by_one = true)
         end
+        close(openfile)
     end
 
-    close(openfile)
     return
 
     equals_names = var_same
@@ -62,15 +62,6 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
             end
         else
             compare_objective(model1,model2,lists, openfile, tol, compare_one_by_one)
-        end
-    end
-
-    if get_bounds
-        if separate_files
-            openbnd = open(outbnd,"w+")
-            compare_bounds(model1,model2,lists, openbnd, tol, compare_one_by_one)
-        else
-            compare_bounds(model1,model2,lists, openfile, tol, compare_one_by_one)
         end
     end
 
@@ -97,26 +88,26 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
 end
 
 function call_compare(args)
-    parsed_args = parse_commandline(args)
-    file1 = parsed_args["file1"]
-    dirfile1 = dirname(file1)
-    file2 = parsed_args["file2"]
-    outfile = joinpath(dirfile1,parsed_args["output"])
-    tol = parsed_args["tol"]
-    separate_files = parsed_args["different-files"]
+    parsed_args        = parse_commandline(args)
+    file1              = parsed_args["file1"]
+    dirfile1           = dirname(file1)
+    file2              = parsed_args["file2"]
+    outfile            = joinpath(dirfile1,parsed_args["output"])
+    tol                = parsed_args["tol"]
+    separate_files     = parsed_args["different-files"]
     compare_one_by_one = true
-    verbose = parsed_args["verbose"]
+    verbose            = parsed_args["verbose"]
     return compare_models(
-        file1 = file1,
-        file2 = file2,
-        get_objective = true,
-        get_constraints = true,
-        get_bounds = true,
-        outfile = outfile,
-        tol = tol,
-        separate_files = separate_files,
+        file1              = file1,
+        file2              = file2,
+        get_objective      = true,
+        get_constraints    = true,
+        get_bounds         = true,
+        outfile            = outfile,
+        tol                = tol,
+        separate_files     = separate_files,
         compare_one_by_one = true,
-        verbose = verbose
+        verbose            = verbose
     )
 end
 

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -6,17 +6,21 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
         println("Outfile: $outfile")
         println("Tol:     $tol")
     end
+
     if separate_files
-        outvar = outfile[1:end-4] * "_variables.txt"
-        outobj = outfile[1:end-4] * "_objective.txt"
-        outbnd = outfile[1:end-4] * "_bounds.txt"
-        outcon = outfile[1:end-4] * "_constraints.txt"
+        (basename, ext) = Base.Filesystem.splitext(outfile)
+        outvar = "$(basename)_variables$(ext)"
+        outobj = "$(basename)_object$(ext)"
+        outbnd = "$(basename)_bounds$(ext)"
+        outcon = "$(basename)_constraints$(ext)"
     else
-        if !isdir(dirname(outfile))
-            mkdir(dirname(outfile))
-        end
+        mkpath(dirname(outfile))
         openfile = open(outfile,"w+")
-    end 
+    end
+
+    model1 = readmodel(file1)
+    model2 = readmodel(file2)
+
     model1,model2 = read_from_file(file1, file2)
     sorted_variable_1 = sort(collect(model1.var_to_name), by=x->x[2])
     sorted_variable_2 = sort(collect(model2.var_to_name), by=x->x[2])
@@ -49,7 +53,7 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
             compare_bounds(model1,model2,lists, openfile, tol, compare_one_by_one)
         end
     end
-    
+
     if get_constraints
         if separate_files
             opencon = open(outcon,"w+")
@@ -58,7 +62,7 @@ function compare_models(; file1 = file1::String, file2 = file2::String, get_obje
             compare_constraints(model1,model2,lists, openfile, tol, compare_one_by_one)
         end
     end
-    
+
     if separate_files
         close(openvar)
         if get_objective

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,79 +1,122 @@
-function compare_constraints(model1, model2, lists, openfile, tol, compare_one_by_one)
-    sorted_cons_1 = sort(collect(model1.con_to_name), by=x->x[2])
-    sorted_cons_2 = sort(collect(model2.con_to_name), by=x->x[2])
-    equals_names,equals_names_index_1,equals_names_index_2,diffs2,diffs2_index,diffs1,diffs1_index = lists
-    all_cons_1 = [[MOI.get(model1,MOI.ConstraintFunction(),con[1]),con[2]] for con in sorted_cons_1]
-    all_cons_2 = [[MOI.get(model2,MOI.ConstraintFunction(),con[1]),con[2]] for con in sorted_cons_2]
-    all_sets_1 = [[MOI.get(model1,MOI.ConstraintSet(),con[1]),con[2]] for con in sorted_cons_1]
-    all_sets_2 = [[MOI.get(model2,MOI.ConstraintSet(),con[1]),con[2]] for con in sorted_cons_2]
-    n_cons_1 = length(all_cons_1)
-    n_cons_2 = length(all_cons_2)
-    equal_cons = []
-    diff_1_cons = []
-    diff_2_cons = []
-    i,j = 1,1
-    print_constraint = true
-    check_print_header = true
+struct ConstraintNamesDiff
+    in_both  :: Vector{String}
+    only_one :: Vector{String}
+    only_two :: Vector{String}
+end
 
-    p = ProgressMeter.ProgressUnknown("Comparing constraints...")
-    while true
-        if i <= n_cons_1 && j <= n_cons_2
-            if all_cons_1[i][2] == all_cons_2[j][2]
-                push!(equal_cons, all_cons_2[j][2])
-                print_constraint, check_print_header = compare_expressions(all_cons_1[i][1],all_cons_2[j][1],model1,model2,openfile,tol,print_constraint, all_cons_1[i][2],compare_one_by_one, check_print_header)
-                if typeof(all_sets_1[i][1]) == typeof(all_sets_2[j][1])
-                    equal = 0
-                    for field in fieldnames(typeof(all_sets_1[i][1]))
-                        if abs(getfield(all_sets_1[i][1], field) - getfield(all_sets_2[j][1], field)) <= tol
-                            equal += 1
-                        end
-                    end
-                    if equal != length(fieldnames(typeof(all_sets_1[i][1])))
-                        if check_print_header 
-                            print_header(openfile, "CONSTRAINTS")
-                            check_print_header = false
-                        end
-                        if print_constraint
-                            write(openfile, "\n")
-                            write(openfile, "CONSTRAINT: ", all_cons_1[i][2],"\n")
-                        end
-                        write(openfile, "\tSETS","\n")
-                        write(openfile, "\t\tMODEL 1: ", remove_quotes(string(all_sets_1[i][1])),"\n")
-                        write(openfile, "\t\tMODEL 2: ", remove_quotes(string(all_sets_2[j][1])),"\n")
-                        write(openfile, "\n")
-                    end
-                else
-                    if check_print_header 
-                        print_header(openfile, "CONSTRAINTS")
-                        check_print_header = false
-                    end
-                    if print_constraint
-                        write(openfile, "\n")
-                        write(openfile, "CONSTRAINT: ", all_cons_1[i][2],"\n")
-                    end
-                    write(openfile, "\tSETS","\n")
-                    write(openfile, "\t\tMODEL 1: ", remove_quotes(string(all_sets_1[i][1])),"\n")
-                    write(openfile, "\t\tMODEL 2: ", remove_quotes(string(all_sets_2[j][1])),"\n")
-                    write(openfile, "\n")
-                end
-                i += 1
-                j += 1
-            elseif all_cons_1[i][2] > all_cons_2[j][2]
-                push!(diff_2_cons, all_cons_2[j][2])
-                j += 1
-            elseif all_cons_1[i][2] < all_cons_2[j][2]
-                push!(diff_1_cons, all_cons_1[i][2])
-                i += 1
-            end
-        elseif i > n_cons_1 && !(j > n_cons_2)
-            push!(diff_2_cons, all_cons_2[j][2])
-            j += 1
-        elseif !(i > n_cons_1) && j > n_cons_2
-            push!(diff_1_cons, all_cons_1[i][2])
-            i += 1
+# Compare expression of constraints and objective function
+# Then, compare bounds of constraints
+struct ConstraintElementsDiff
+    equal::Vector{String}
+    both::Dict{String, Tuple{ExpressionDiff, Tuple{Tuple{Float64, Float64}, Tuple{Float64, Float64}}}}
+    first::Dict{String, Tuple{Dict{String, Float64}, Tuple{Float64, Float64}}}
+    second::Dict{String, Tuple{Dict{String, Float64}, Tuple{Float64, Float64}}}
+end
+
+function compare_constraints(model1::MOI.ModelLike, model2::MOI.ModelLike; tol::Float64)
+    condiff = ConstraintNamesDiff(partition(constraint_names(model1), constraint_names(model2))...)
+    ctrindices1 = ctr_index_for_name(model1)
+    ctrindices2 = ctr_index_for_name(model2)
+    con_first = Dict(name => 
+                    (
+                        Dict(model1.var_to_name[var.variable] => var.coefficient
+                        for var in MOI.get(model1, MOI.ConstraintFunction(), ctrindices1[name]).terms),
+                        constraint_set_to_bound(MOI.get(model1, MOI.ConstraintSet(), ctrindices1[name])))
+                    for name in condiff.only_one)
+    con_second = Dict(name => 
+                    (
+                        Dict(model2.var_to_name[var.variable] => var.coefficient
+                        for var in MOI.get(model2, MOI.ConstraintFunction(), ctrindices2[name]).terms),
+                        constraint_set_to_bound(MOI.get(model2, MOI.ConstraintSet(), ctrindices2[name])))
+                    for name in condiff.only_two)
+
+    p = ProgressMeter.Progress(length(condiff.in_both), "Comparing constraints...")
+    con_both = Dict{String, Tuple{ExpressionDiff, Tuple{Tuple{Float64, Float64}, Tuple{Float64, Float64}}}}()
+    equal = String[]
+
+    for name in condiff.in_both
+        f1 = MOI.get(model1, MOI.ConstraintSet(), ctrindices1[name])
+        f2 = MOI.get(model2, MOI.ConstraintSet(), ctrindices2[name])
+        set1 = constraint_set_to_bound(f1)
+        set2 = constraint_set_to_bound(f2)
+        
+        expression_diff = compare_expressions(
+                MOI.get(model1, MOI.ConstraintFunction(), ctrindices1[name]), 
+                MOI.get(model2, MOI.ConstraintFunction(), ctrindices2[name]),
+                model1,
+                model2;
+                tol = tol
+                )
+        if all(isapprox.(set1, set2; atol = tol)) && 
+            isempty(expression_diff.both) &&
+            isempty(expression_diff.first) &&
+            isempty(expression_diff.second)
+            push!(equal, name)
         else
-            break
+            con_both[name] = (expression_diff, (set1, set2))
         end
-        ProgressMeter.next!(p)
+        next!(p)
+    end
+
+    return ConstraintElementsDiff(sort!(equal), con_both, con_first, con_second)
+end
+
+function printdiff(io::IO, con_diff::ConstraintElementsDiff; one_by_one::Bool)
+    equal, both, only1, only2 = con_diff.equal, con_diff.both, con_diff.first, con_diff.second
+
+    if !isempty(only1) || !isempty(only2) || !isempty(both)
+        print_header(io, "CONSTRAINTS")
+    end
+
+    if !isempty(both)
+        write(io, "SAME CONSTRAINTS:\n\n")
+        for (name, (expression_diff, (set1, set2))) in both
+            printdiff(io, expression_diff, name; one_by_one = one_by_one)
+            write(io, "\tSETS:\n")
+            write(io, "\t\t", "MODEL 1 => ", string(set1) ,"\n")
+            write(io, "\t\t", "MODEL 2 => ", string(set2) ,"\n\n")
+        end
+    end
+
+    if !isempty(only1) || !isempty(only2)
+        write(io, "\tDIFFERENT CONSTRAINTS:\n")
+    end
+
+    if !isempty(only1)
+        write(io, "\t", "MODEL 1:", "\n")
+        for (name, (coefs, set)) in only1
+            write(io, "\t\t", name, ":\n")
+            write(io, "\t\t\tSET:", string(set) ,"\n")
+            for (var, coef) in coefs
+                write(io, "\t\t\t", var, " => ", string(coef) ,"\n")
+            end
+            write(io, "\n")
+        end
+    end
+
+    if !isempty(only2)
+        write(io, "\t", "MODEL 2:", "\n")
+        for (name, (coefs, set)) in only2
+            write(io, "\t\t", name, ":\n")
+            write(io, "\t\t\t SET:", string(set) ,"\n")
+            for (var, coef) in coefs
+                write(io, "\t\t\t", var, " => ", string(coef) ,"\n")
+            end
+        end
     end
 end
+
+function constraint_names(m::MOI.ModelLike)
+    # TODO: Can we extract this without snooping into the model's private fields?
+    # That is, only with MOI.get?
+    return values(m.con_to_name)
+end
+
+function ctr_index_for_name(m::MOI.ModelLike)
+    return Dict(v => k for (k, v) in m.con_to_name)
+end
+
+constraint_set_to_bound(constraint_set::MOI.LessThan{T}) where {T} = (typemin(T), constraint_set.upper)
+constraint_set_to_bound(constraint_set::MOI.GreaterThan{T}) where {T} = (constraint_set.lower, typemax(T))
+constraint_set_to_bound(constraint_set::MOI.Interval{T}) where {T} = (constraint_set.lower, constraint_set.upper)
+constraint_set_to_bound(constraint_set::MOI.EqualTo{T}) where {T} = (constraint_set.value, constraint_set.value)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -1,27 +1,33 @@
-function compare_objective(model1, model2, lists, openfile, tol, compare_one_by_one)
-    printconstraint = true
-    equals_names,equals_names_index_1,equals_names_index_2,diffs2,diffs2_index,diffs1,diffs1_index = lists
-    
-    if MOI.get(model1,MOI.ObjectiveSense()) == MOI.get(model2,MOI.ObjectiveSense())
-        #write(openfile, "EQUAL SENSE: ", string(MOI.get(model2,MOI.ObjectiveSense())),"\n")
-        nothing
-    else
-        write(openfile, "\tUNIQUE SENSE MODEL 1: ", string(MOI.get(model2,MOI.ObjectiveSense())),"\n")
-        write(openfile, "\tUNIQUE SENSE MODEL 2: ", string(MOI.get(model2,MOI.ObjectiveSense())),"\n")
-    end
-    
-    n_var_1 = MOI.get(model1,MOI.NumberOfVariables())
-    n_var_2 = MOI.get(model2,MOI.NumberOfVariables())
+struct ObjectiveDiff
+    sense::Tuple{MOI.OptimizationSense, MOI.OptimizationSense}
+    expression::ExpressionDiff
+end
+
+function compare_objective(model1::MOI.ModelLike, model2::MOI.ModelLike; tol::Float64)
+    sense1 = MOI.get(model1, MOI.ObjectiveSense())
+    sense2 = MOI.get(model2, MOI.ObjectiveSense())
     attr1 = MOI.get(model1, MOI.ObjectiveFunctionType())
     attr2 = MOI.get(model2, MOI.ObjectiveFunctionType())
     objective1 = MOI.get(model1,MOI.ObjectiveFunction{attr1}())
     objective2 = MOI.get(model2,MOI.ObjectiveFunction{attr2}())
-    
-    if attr1 != attr2
-        write(openfile, "\tOBJECTIVE TYPES ARE DIFFERENT:","\n")
-        write(openfile, "\t\tMODEL 1: ",attr1,"\n")
-        write(openfile, "\t\tMODEL 2: ",attr2,"\n")
-    else
-        compare_expressions(objective1,objective2,model1,model2,openfile,tol,printconstraint, "OBJECTIVE", compare_one_by_one, false)
+    expression_diff = compare_expressions(
+        objective1, 
+        objective2,
+            model1,
+            model2;
+            tol = tol
+        )
+    return ObjectiveDiff((sense1, sense2), expression_diff)
+end
+
+function printdiff(io::IO, odiff::ObjectiveDiff; one_by_one::Bool)
+    sense1, sense2 = odiff.sense
+    expression_diff = odiff.expression
+    print_header(io, "OBJECTIVE")
+    if sense1 != sense2
+        write(io, "\tOBJECTIVE SENSES ARE DIFFERENT:","\n")
+        write(io, "\t\tMODEL 1: ",sense1,"\n")
+        write(io, "\t\tMODEL 2: ",sense2,"\n")
     end
+    printdiff(io, expression_diff, "OBJECTIVE"; one_by_one = one_by_one)
 end

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -1,6 +1,8 @@
-function sort_model(file1::String, file2::String)
+function sort_model(file1::String)
 
-    src,dest = ModelCompare.read_from_file_copy(file1, file2)
+    src = readmodel(file1)
+    file2 = file1*".sorted"
+    dest = MOIF.Model(filename = file2)
     sorted_variable_1 = sort(collect(src.var_to_name), by=x->x[2])
     all_variables_1 = [[var[1],var[2]] for var in sorted_variable_1]
     moi_vi_indices = hcat(all_variables_1...)[1,:]
@@ -66,7 +68,8 @@ function sort_model(file1::String, file2::String)
 
     sense1 = MOI.get(src,MOI.ObjectiveSense())
     MOI.set(dest,MOI.ObjectiveSense(),sense1)
-
+    T = Float64
+    
     for i in indices
         if MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(i))
             ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(i)
@@ -78,23 +81,23 @@ function sort_model(file1::String, file2::String)
             f = MOI.get(src, MOI.ConstraintFunction(), ci)
             s = MOI.get(src, MOI.ConstraintSet(), ci)
             MOI.add_constraint(dest, MOIU.map_indices(idx_map_model1_to_2, f), s)
-        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo}(i))
-            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo}(i)
+        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{T}}(i))
+            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{T}}(i)
             f = MOI.get(src, MOI.ConstraintFunction(), ci)
             s = MOI.get(src, MOI.ConstraintSet(), ci)
             MOI.add_constraint(dest, MOIU.map_indices(idx_map_model1_to_2, f), s)
-        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan}(i))
-            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan}(i)
+        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}}(i))
+            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}}(i)
             f = MOI.get(src, MOI.ConstraintFunction(), ci)
             s = MOI.get(src, MOI.ConstraintSet(), ci)
             MOI.add_constraint(dest, MOIU.map_indices(idx_map_model1_to_2, f), s)
-        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan}(i))
-            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan}(i)
+        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{T}}(i))
+            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{T}}(i)
             f = MOI.get(src, MOI.ConstraintFunction(), ci)
             s = MOI.get(src, MOI.ConstraintSet(), ci)
             MOI.add_constraint(dest, MOIU.map_indices(idx_map_model1_to_2, f), s)
-        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval}(i))
-            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval}(i)
+        elseif MOI.is_valid(src,MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{T}}(i))
+            ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{T}}(i)
             f = MOI.get(src, MOI.ConstraintFunction(), ci)
             s = MOI.get(src, MOI.ConstraintSet(), ci)
             MOI.add_constraint(dest, MOIU.map_indices(idx_map_model1_to_2, f), s)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,9 @@
+function readmodel(fname)
+    m = MOIF.Model(filename = fname)
+    MOI.read_from_file(m, fname)
+    return m
+end
+
 function read_from_file(file1::String, file2::String)
     model1 = MOIF.Model(filename = file1)
     MOI.read_from_file(model1, file1)
@@ -21,4 +27,17 @@ function print_header(openfile, string)
     write(openfile, "\n", "#"^80, "\n")
     write(openfile, string, "\n")
     write(openfile, "#"^80, "\n\n")
+end
+
+"""
+    partition(A, B)
+
+Partition two collections into disjoint collections
+containing their intersection and the elements unique to each of them:
+
+    partition(A, B) = (A ∩ B, A \\ B, B \\ A)
+"""
+function partition(xs, ys)
+    inter = intersect(xs, ys)
+    return inter, setdiff(xs, inter), setdiff(ys, inter)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,22 +1,7 @@
-function readmodel(fname)
+function readmodel(fname::String)
     m = MOIF.Model(filename = fname)
     MOI.read_from_file(m, fname)
     return m
-end
-
-function read_from_file(file1::String, file2::String)
-    model1 = MOIF.Model(filename = file1)
-    MOI.read_from_file(model1, file1)
-    model2 = MOIF.Model(filename = file2)
-    MOI.read_from_file(model2, file2)
-    return model1,model2
-end
-
-function read_from_file_copy(file1::String, file2::String)
-    model1 = MOIF.Model(filename = file1)
-    MOI.read_from_file(model1, file1)
-    model2 =MOIF.Model(filename = file2)
-    return model1,model2
 end
 
 function remove_quotes(string::String)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -14,7 +14,7 @@ function printdiff(io::IO, vardiff::VariablesDiff)
 
     p = ProgressUnknown("Comparing variables...")
 
-    if !isempty(only1) || !isempty(only)
+    if !isempty(only1) || !isempty(only2)
         print_header(io, "VARIABLE NAMES")
         next!(p)
     end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,28 +1,41 @@
-function compare_variables(model1::MOI.ModelLike, model2::MOI.ModelLike, openfile)
+struct VariablesDiff
+    in_both  :: Vector{String}
+    only_one :: Vector{String}
+    only_two :: Vector{String}
+end
+
+function compare_variables(model1::MOI.ModelLike, model2::MOI.ModelLike)
+    return  VariablesDiff(partition(variable_names(model1), variable_names(model2))...)
+end
+
+
+function printdiff(io::IO, vardiff::VariablesDiff)
+    only1, only2 = vardiff.only_one, vardiff.only_two
+
     p = ProgressUnknown("Comparing variables...")
 
-    inboth, only1, only2 = partition(variable_names(model1), variable_names(model2))
-
     if !isempty(only1) || !isempty(only)
-        print_header(openfile, "VARIABLE NAMES")
+        print_header(io, "VARIABLE NAMES")
         next!(p)
     end
 
     if !isempty(only1)
-        write(openfile, "\tMODEL 1\n")
+        write(io, "\tOnly MODEL 1\n")
         for vname in only1
-            write(openfile,"\t\t", vname,"\n")
+            write(io,"\t\t", vname,"\n")
             next!(p)
         end
     end
 
     if !isempty(only2)
-        write(openfile, "\tMODEL 2\n")
+        write(io, "\tOnly MODEL 2\n")
         for vname in only2
-            write(openfile,"\t\t", vname,"\n")
+            write(io,"\t\t", vname,"\n")
             next!(p)
         end
     end
+
+    return vardiff
 end
 
 """
@@ -34,4 +47,8 @@ function variable_names(m::MOI.ModelLike)
     # TODO: Can we extract this without snooping into the model's private fields?
     # That is, only with MOI.get?
     return values(m.var_to_name)
+end
+
+function index_for_name(m::MOI.ModelLike)
+    return Dict(v => k for (k, v) in m.var_to_name)
 end

--- a/test/test_simple.jl
+++ b/test/test_simple.jl
@@ -1,29 +1,29 @@
 using ModelCompare
 
 @time compare_models(
-    file1 = "test/models/model1.mps",
-    file2 = "test/models/model2.mps",
+    "test/models/model1.mps",
+    "test/models/model2.mps",
     outfile = "test/models/compare_mps.txt", 
-    tol = 0
+    tol = 0.0
 )
 
 @time compare_models(
-    file1 = "test/models/model1.lp",
-    file2 = "test/models/model2.lp",
+    "test/models/model1.lp",
+    "test/models/model2.lp",
     outfile = "test/models/compare_lp.txt",
-    tol = 0
+    tol = 0.0
 )
 
 @time compare_models(
-    file1 = "test/models/modelbiglp1.mps",
-    file2 = "test/models/modelbiglp2.mps",
+    "test/models/modelbiglp1.mps",
+    "test/models/modelbiglp2.mps",
     outfile = "test/models/comparebiglp_mps.txt", 
-    tol = 0
+    tol = 0.0
 )
 
 @time compare_models(
-    file1 = "test/models/modelbiglp1.lp",
-    file2 = "test/models/modelbiglp2.lp",
+    "test/models/modelbiglp1.lp",
+    "test/models/modelbiglp2.lp",
     outfile = "test/models/comparebiglp_lp.txt", 
-    tol = 0
+    tol = 0.0
 )

--- a/test/test_sort.jl
+++ b/test/test_sort.jl
@@ -1,6 +1,5 @@
 using ModelCompare
 
 ModelCompare.sort_model(
-    raw"test\models\model1.lp",
-   raw"test\models\model1_sorted.lp"
+    raw"test\models\model1.lp"
 )


### PR DESCRIPTION
The idea is to rewrite the main method `compare_models` into smaller parts that could be swapped up in the future.
By first creating an in-memory representation of a comparison, it is much easier to print for different formats afterwards.
Besides the current human-readable format, I was thinking about some machine-processable outputs such as CSV and JSON.

Furthermore, having an internal representation makes life much easier when it comes to unit testing the code.

This is still a draft, and any comments are more than welcome.

By now, we have a refactor for:
- [x] Variables
- [x] Bounds
- [x] Constraints
- [x] Objective